### PR TITLE
Fix sign_up form error and add missing ja.errors.messages translations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module Photogram
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -142,3 +142,5 @@ ja:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: '%{count} 件のエラーが発生したため %{resource} は保存されませんでした。'
       blank: 'を入力してください'
+      too_long: 'は %{count}文字以内 で入力してください'
+      taken: '%{value} はすでに存在します'

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     attributes:
       user:
+        account: アカウント
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
         confirmed_at: パスワード確認時刻
@@ -140,3 +141,4 @@ ja:
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: '%{count} 件のエラーが発生したため %{resource} は保存されませんでした。'
+      blank: 'を入力してください'


### PR DESCRIPTION
## 概要

`devise`の新規登録フォームにて、以下のエラーが発生していたため修正を行いました。

```
NoMethodError at /users/sign_up
undefined method `account’ for #user:...
```

また、エラーメッセージに関して `ja.errors.messages.blank` などの翻訳キーが存在せず `translation missing` が表示されていたため、`ja.yml` に以下の翻訳を追記しました。

## 主な変更点

- `config/locales/devise.ja.yml` に不足していたエラーメッセージ翻訳を追加

```yaml
ja:
  errors:
    messages:
      blank: 'を入力してください'
      too_long: 'は %{count}文字以内 で入力してください'
      taken: '%{value} はすでに存在します'
```

## 動作確認
ユーザーサインイン時のエラーメッセージが正常に表示されることを確認
<img width="628" height="260" alt="image" src="https://github.com/user-attachments/assets/86618c7c-379e-4a15-8e30-f7eee4d886fb" />

## 備考

翻訳に関しては devise の公式日本語ファイルを参考にしつつ、必要最低限のキーのみを追加しています。

## 関連Issue

#5 