### PR TITLE
feat: Add backend validation and flash messaging to avatar upload

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 // Entry point for your Sass build
 @use 'reset';
 @use 'variables';
+@use 'flash';
 @use 'form';
 @use 'common';
 @use 'profile';

--- a/app/assets/stylesheets/flash.scss
+++ b/app/assets/stylesheets/flash.scss
@@ -1,0 +1,17 @@
+.flash {
+  position: fixed;
+  top: 16px;
+  font-size: 12px;
+  right: 16px;
+  width: 200px;
+  background: white;
+  visibility: hidden;
+  z-index: 1;
+  padding: 12px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.125);
+
+  &.flash-notice,
+  &.flash-alert {
+    visibility: visible;
+  }
+}

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -21,6 +21,10 @@ $image_size: variables.$avatar-l;
       border-radius: 50%;
       padding: 2px;
     }
+
+    #avatar-input {
+      display: none;
+    }
   }
 
   .achievement {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,6 @@
 // Rails のベースライブラリ
-import Rails from "@rails/ujs"
-Rails.start()
+import Rails from '@rails/ujs';
+Rails.start();
 
 // Turbo の読み込み
 import '@hotwired/turbo-rails';
@@ -41,11 +41,33 @@ document.addEventListener('turbo:load', () => {
           // 返ってきた avatar_url を使って再描写
           $('#avatar-preview').attr('src', res.data.avatar_url);
         }
-        alert('プロフィール画像を更新しました');
+        flash('プロフィール画像を更新しました');
       })
       .catch((e) => {
         console.error('Upload error', e);
-        alert('アップロードに失敗しました');
+        flash('アップロードに失敗しました');
       });
   });
 });
+
+// flash 表示
+function flash(message, type = 'notice') {
+  const flash = $('.flash');
+
+  // 要素が存在しない場合は何もしない
+  if (flash.length === 0) {
+    console.warn('.flash element is not found');
+    return;
+  }
+
+  // クラスを設定
+  flash.removeClass().addClass(`flash flash-${type}`);
+
+  // メッセージ設定と表示
+  flash.text(message).show();
+
+  // 一定時間後に非表示（3秒）
+  setTimeout(() => {
+    flash.fadeOut(400);
+  }, 3000);
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,11 +10,26 @@ class User < ApplicationRecord
                       length: { maximum: 25 },
                       uniqueness: true
 
+  validate :avatar_content_type
+  validate :avatar_size
+
   def avatar_img
     if self.avatar&.attached?
       self.avatar
     else
       'default.svg'
+    end
+  end
+
+  def avatar_content_type
+    if avatar.attached? && !avatar.content_type.in?(%w[image/jpeg image/png image/gif])
+      errors.add(:avatar, '：JPEG、PNG、GIFのみアップロード可能です')
+    end
+  end
+
+  def avatar_size
+    if avatar.attached? && avatar.blob&.byte_size > 5.megabytes
+      errors.add(:avatar, '：5MB 以下のファイルのみアップロード可能です')
     end
   end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,7 +28,8 @@
       - elsif !current_page?(new_user_session_path)
         = link_to 'Log in', new_user_session_path
 
-    %p.notice= notice
-    %p.alert= alert
+    .flash
+      - flash.each do |key, value|
+        %div{:class => key}= value
 
     = yield

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -6,7 +6,7 @@
       .avatar
         = image_tag current_user.avatar_img, id: 'avatar-preview'
         = form_with url: '#', html: { id: "avatar-form", enctype: "multipart/form-data" }, local: true do
-          = file_field_tag :avatar, id: "avatar-input", style: "display: none;", accept: "image/png,image/jpeg"
+          = file_field_tag :avatar, id: "avatar-input", accept: "image/png,image/jpeg"
       .achievement
         .block
           .count


### PR DESCRIPTION
## 変更の概要
- アバター画像アップロードに対してバックエンドでのバリデーションを追加しました
- アラート表示を alert() から flash メッセージ方式に置き換えました
- 関連Issue: 
   - close #7
   - close #9 

## なぜこの変更をするのか
- ユーザーが不正なファイル（画像以外など）をアップロードしようとした際に、適切にエラーメッセージを表示する必要があったため
- JavaScript の alert() デザインと合わないため flash メッセージに置き換えたかった
- コードの可読性と保守性を高めるため、インラインスタイルをCSSに分離した

## やったこと
- アップロードされるファイルが画像であるかをバリデーション（バックエンド）
- エラーや成功時に flash メッセージを表示するように変更（フロントエンド）
- .avatar 関連のスタイルを stylesheet に整理

## 変更内容
- UIの変更（スクリーンショット省略：小規模なトースト通知の見た目のみの変更）
- APIのレスポンスは変更なし。ただし失敗時にはステータスコードとメッセージが返るように整理

## 影響範囲
- ユーザーは、画像アップロード成功・失敗時に適切なメッセージを受け取れるようになります
- 開発者は、alert() を使わず flash に統一できるようになります
- システム的には、セキュリティ上のバリデーションが強化されます（非画像ファイルのアップロード防止）

## 動作確認
- ログイン状態でプロフィール画像をクリック → ファイル選択 → 成功時：画像が更新され、flashメッセージ表示

   https://github.com/user-attachments/assets/28c7c0c7-2e01-43e4-bc19-2458ef5bf542

- 既存の画像アップロード機能が壊れていないことを確認済み