### PR TITLE
Feature/share on x

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,6 +4,10 @@ class PostsController < ApplicationController
     @posts = Post.all
   end
 
+  def show
+    @post = Post.find(params[:id])
+  end
+
   def new
     @post = current_user.posts.build
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,4 +16,8 @@
 class Post < ApplicationRecord
   has_many_attached :images
   belongs_to :user
+
+  def url
+    Rails.application.routes.url_helpers.post_url(self, host: "http://localhost:3000")
+  end
 end

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -20,7 +20,8 @@
             .sign
               = image_tag 'comment.svg'
             .sign
-              = image_tag 'link.svg'
+              = link_to "https://twitter.com/share?url=#{CGI.escape(post.url)}&text=#{CGI.escape("【テスト】\n\n#{post.caption}")}", target: "_blank", rel: "noopener" do
+                = image_tag 'link.svg'
           .post-like
             Jasmine and 12,000 other liked your post
           .caption

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,0 +1,30 @@
+.container
+  .card
+    .post
+      .post-header
+        .avatar-img
+          = image_tag @post.user.avatar
+        .post-info
+          .post-user
+            = @post.user.account
+          .post-ago
+            = "#{time_ago_in_words(@post.created_at)} ago"
+      .post-content
+        .content-images
+          = image_tag @post.images[0] if @post.images[0].present?
+      .post-footer
+        .group
+          .sign
+            = image_tag 'heart-blank.svg'
+          .sign
+            = image_tag 'comment.svg'
+          .sign
+            = link_to "https://twitter.com/share?url=#{CGI.escape(@post.url)}&text=#{CGI.escape("【テスト】\n\n#{@post.caption}")}", target: "_blank", rel: "noopener" do
+              = image_tag 'link.svg'
+        .post-like
+          Jasmine and 12,000 other liked your post
+        .caption
+          .caption-user
+            = @post.user.account
+          .caption-content
+            = @post.caption


### PR DESCRIPTION
## 概要
- 投稿詳細画面の表示機能を追加し、各投稿ページにXへのシェアリンクを実装しました。

## 変更内容
- PostsController に show アクションを追加
- posts/show.html.haml を作成し、投稿の内容（画像・キャプション）を表示
- 詳細ページにXへのシェアリンクを設置
- https://twitter.com/share を使用
- URLとキャプションを含めた投稿が可能

## スクリーンショット

### posts/show
<img width="494" height="502" alt="image" src="https://github.com/user-attachments/assets/65966e1d-5a6e-40eb-9456-25298b5fa45c" />

### Xシェアリンク

https://github.com/user-attachments/assets/075c49ba-050e-4a6b-b73f-abd312e1b413


## 動作確認手順
1. 投稿詳細画面が表示されることを確認
2. 「Share on X」リンクをクリックし、新しいタブでX投稿画面が開くことを確認
3. 同様に、タイムライン上のリンクでもそれぞれのPostのリンクが作成されることを確認