### PR TITLE
Implement Bootstrap-based UI and responsive image preview layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'kamal', require: false
 gem 'thruster', require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,14 @@ GEM
     erubis (2.7.0)
     et-orbi (1.2.11)
       tzinfo
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -157,6 +165,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -193,6 +204,8 @@ GEM
     marcel (1.0.4)
     matrix (0.4.3)
     method_source (1.1.0)
+    mini_magick (5.3.0)
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -335,6 +348,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.4)
+      ffi (~> 1.12)
+      logger
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
@@ -433,6 +449,7 @@ DEPENDENCIES
   hamlit
   hamlit-rails
   html2haml
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails (~> 1.3)
   kamal

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @use 'reset';
 @use 'variables';
 @use 'flash';
+@use "bootstrap/scss/bootstrap";
 @use 'form';
 @use 'common';
 @use 'post';

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -47,6 +47,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    margin-bottom: 40px;
 
     // ページタイトル
     .heading {

--- a/app/assets/stylesheets/post.scss
+++ b/app/assets/stylesheets/post.scss
@@ -34,7 +34,6 @@ $image_size: variables.$avatar-s;
     .content-images {
       width: 375px;
       min-height: 225px;
-      background-color: skyblue;
       margin-bottom: 15px;
 
       img {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-    @posts = Post.all
+    @posts = Post.all.order(created_at: :desc)
   end
 
   def show

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,6 +12,8 @@ import axios from 'axios';
 // Stimulus Controllers
 import './controllers';
 
+import * as bootstrap from 'bootstrap';
+
 document.addEventListener('turbo:load', () => {
   // 画像クリック → inputをトリガー
   $('#avatar-preview').on('click', () => {

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,9 @@
-import { Application } from "@hotwired/stimulus"
+import { Application } from '@hotwired/stimulus';
 
-const application = Application.start()
+const application = Application.start();
 
 // Configure Stimulus development experience
-application.debug = false
-window.Stimulus   = application
+application.debug = false;
+window.Stimulus = application;
 
-export { application }
+export { application };

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,7 +17,38 @@ class Post < ApplicationRecord
   has_many_attached :images
   belongs_to :user
 
+  validates :caption, length: { maximum: 400 }
+
+  validate :images_content_type
+  validate :images_size
+  validate :images_count
+
   def url
     Rails.application.routes.url_helpers.post_url(self, host: "http://localhost:3000")
   end
+
+  def images_content_type
+    return unless images.attached?
+
+    unless images.all? { |image| image.content_type.in?(%w[image/jpeg image/png image/gif]) }
+      errors.add(:images, '：JPEG、PNG、GIFのみアップロード可能です')
+    end
+  end
+
+  def images_size
+    return unless images.attached?
+
+    if images.any? { |image| image.blob.byte_size > 5.megabytes }
+      errors.add(:images, '：5MB 以下のファイルのみアップロード可能です')
+    end
+  end
+
+  def images_count
+    return unless images.attached?
+
+    if images.size > 8
+      errors.add(:images, '：8 枚までアップロード可能です')
+    end
+  end
+
 end

--- a/app/views/posts/_modal.html.haml
+++ b/app/views/posts/_modal.html.haml
@@ -1,0 +1,7 @@
+.modal.fade{id: "imageModal-#{post_id}-#{index}", tabindex: "-1", role: "dialog", aria: { labelledby: "modalLabel-#{post_id}-#{index}", hidden: true } }
+  .modal-dialog.modal-dialog-centered.modal-xl
+    .modal-content
+      .modal-header
+        %button.btn-close{ type: "button", data: { bs_dismiss: "modal" }, aria: { label: "Close" } }
+      .modal-body.text-center
+        = image_tag(image.variant(resize_to_limit: [900, 900]), alt: "large image #{index + 1}", class: "img-fluid")

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -12,27 +12,106 @@
               = "#{time_ago_in_words(post.created_at)} ago"
         .post-content
           .content-images
+            - case post.images.size
+            - when 1
+              .row
+                .col
+                  = image_tag(post.images[0].variant(resize_to_fill: [600, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-0" })
+                  = render "modal", image: post.images[0], index: 0, post_id: post.id
 
-            .row.g-1.mb-4
-              - post.images.each_with_index do |image, index|
-                .col{:class => "col-#{12 / [post.images.size, 4].min}"}
+            - when 2
+              .row.g-1
+                - post.images.each_with_index do |image, index|
+                  .col-6
+                    = image_tag(image.variant(resize_to_fill: [150, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{index}" })
+                    = render "modal", image: image, index: index, post_id: post.id
 
-                  = image_tag(image.variant(resize_to_limit: [300, 300]),
-                              alt: "post image #{index + 1}",
-                              class: "img-fluid",
-                              data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{index}" })
+            - when 3
+              .row.g-1
+                .col-md-8
+                  = image_tag(post.images[0].variant(resize_to_fill: [400, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-0" })
+                  = render "modal", image: post.images[0], index: 0, post_id: post.id
+                .col-md-4
+                  .row.g-0
+                    - post.images[1..2].each_with_index do |image, i|
+                      .col-12.mb-1
+                        = image_tag(image.variant(resize_to_fill: [200, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = render "modal", image: image, index: i + 1, post_id: post.id
 
-                  -# モーダル
-                  .modal.fade{id: "imageModal-#{post.id}-#{index}", tabindex: "-1", role: "dialog", aria: { labelledby: "modalLabel-#{post.id}-#{index}", hidden: true } }
-                    .modal-dialog.modal-dialog-centered.modal-xl
-                      .modal-content
-                        .modal-header
-                          -# %h5.modal-title{id: "modalLabel-#{post.id}-#{index}"} Image Preview
-                          %button.btn-close{ type: "button", data: { bs_dismiss: "modal" }, aria: { label: "Close" } }
-                        .modal-body.text-center
-                          = image_tag(image.variant(resize_to_limit: [900, 900]),
-                                      alt: "large image #{index + 1}",
-                                      class: "img-fluid")
+            - when 4
+              .row.g-1
+                .col-md-8
+                  = image_tag(post.images[0].variant(resize_to_fill: [400, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-0" })
+                  = render "modal", image: post.images[0], index: 0, post_id: post.id
+                .col-md-4
+                  .row
+                    - post.images[1..3].each_with_index do |image, i|
+                      .col-12.mb-1
+                        = image_tag(image.variant(resize_to_fill: [200, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = render "modal", image: image, index: i + 1, post_id: post.id
+
+            - when 5
+              .row.g-1
+                .col-md-6
+                  = image_tag(post.images[0].variant(resize_to_fill: [300, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-0" })
+                  = render "modal", image: post.images[0], index: 0, post_id: post.id
+                .col-md-6
+                  .row.g-1
+                    - post.images[1..2].each_with_index do |image, i|
+                      .col-6.mb-1
+                        = image_tag(image.variant(resize_to_fill: [150, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = render "modal", image: image, index: i + 1, post_id: post.id
+                  .row.g-1
+                    - post.images[3..4].each_with_index do |image, i|
+                      .col-6.mb-1
+                        = image_tag(image.variant(resize_to_fill: [150, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = render "modal", image: image, index: i + 1, post_id: post.id
+
+            - when 6
+              .row.g-1.mb-1
+                .col-md-6
+                  = image_tag(post.images[0].variant(resize_to_fill: [300, 400]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-0" })
+                  = render "modal", image: post.images[0], index: 0, post_id: post.id
+                .col-md-6
+                  = image_tag(post.images[1].variant(resize_to_fill: [300, 400]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-1" })
+                  = render "modal", image: post.images[1], index: 1, post_id: post.id
+              .row.g-1
+                .col-md-12
+                  .row.g-1
+                    - post.images[2..5].each_with_index do |image, i|
+                      .col-3.mb-1
+                        = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = render "modal", image: image, index: i + 1, post_id: post.id
+
+            - when 7
+              .row.g-1.mb-1
+                .col-md-9
+                  = image_tag(post.images[0].variant(resize_to_fill: [450, 450]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-0" })
+                  = render "modal", image: post.images[0], index: 0, post_id: post.id
+                .col-md-3
+                  - post.images[1..2].each_with_index do |image, i|
+                    .col-12.mb-1
+                      = image_tag(image.variant(resize_to_fill: [150, 225]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: post.id
+              .row.g-1
+                .col-md-12
+                  .row.g-1
+                    - post.images[3..6].each_with_index do |image, i|
+                      .col-3.mb-1
+                        = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = render "modal", image: image, index: i + 1, post_id: post.id
+
+            - when 8
+              .row.g-1
+                .col-md-6
+                  = image_tag(post.images[0].variant(resize_to_fill: [300, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-0" })
+                  = render "modal", image: post.images[0], index: 0, post_id: post.id
+                .col-md-6
+                  .row.g-1
+                    - post.images[1..7].each_with_index do |image, i|
+                      .col-12
+                        = image_tag(image.variant(resize_to_fill: [300, 80]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = render "modal", image: image, index: i + 1, post_id: post.id
 
         .post-footer
           .group

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -12,7 +12,28 @@
               = "#{time_ago_in_words(post.created_at)} ago"
         .post-content
           .content-images
-            = image_tag post.images[0] if post.images[0].present?
+
+            .row.g-1.mb-4
+              - post.images.each_with_index do |image, index|
+                .col{:class => "col-#{12 / [post.images.size, 4].min}"}
+
+                  = image_tag(image.variant(resize_to_limit: [300, 300]),
+                              alt: "post image #{index + 1}",
+                              class: "img-fluid",
+                              data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{index}" })
+
+                  -# モーダル
+                  .modal.fade{id: "imageModal-#{post.id}-#{index}", tabindex: "-1", role: "dialog", aria: { labelledby: "modalLabel-#{post.id}-#{index}", hidden: true } }
+                    .modal-dialog.modal-dialog-centered.modal-xl
+                      .modal-content
+                        .modal-header
+                          -# %h5.modal-title{id: "modalLabel-#{post.id}-#{index}"} Image Preview
+                          %button.btn-close{ type: "button", data: { bs_dismiss: "modal" }, aria: { label: "Close" } }
+                        .modal-body.text-center
+                          = image_tag(image.variant(resize_to_limit: [900, 900]),
+                                      alt: "large image #{index + 1}",
+                                      class: "img-fluid")
+
         .post-footer
           .group
             .sign

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -64,8 +64,8 @@
                   .row.g-1
                     - post.images[3..4].each_with_index do |image, i|
                       .col-6.mb-1
-                        = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
-                        = render "modal", image: image, index: i + 1, post_id: post.id
+                        = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 3}" })
+                        = render "modal", image: image, index: i + 3, post_id: post.id
 
             - when 6
               .row.g-1.mb-1
@@ -80,8 +80,8 @@
                   .row.g-1
                     - post.images[2..5].each_with_index do |image, i|
                       .col-3.mb-1
-                        = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
-                        = render "modal", image: image, index: i + 1, post_id: post.id
+                        = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 2}" })
+                        = render "modal", image: image, index: i + 2, post_id: post.id
 
             - when 7
               .row.g-1.mb-1
@@ -98,8 +98,8 @@
                   .row.g-1
                     - post.images[3..6].each_with_index do |image, i|
                       .col-3.mb-1
-                        = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
-                        = render "modal", image: image, index: i + 1, post_id: post.id
+                        = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 3}" })
+                        = render "modal", image: image, index: i + 3, post_id: post.id
 
             - when 8
               .row.g-1

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -35,7 +35,7 @@
                   .row.g-0
                     - post.images[1..2].each_with_index do |image, i|
                       .col-12.mb-1
-                        = image_tag(image.variant(resize_to_fill: [200, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = image_tag(image.variant(resize_to_fill: [200, 301]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
                         = render "modal", image: image, index: i + 1, post_id: post.id
 
             - when 4
@@ -47,7 +47,7 @@
                   .row
                     - post.images[1..3].each_with_index do |image, i|
                       .col-12.mb-1
-                        = image_tag(image.variant(resize_to_fill: [200, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = image_tag(image.variant(resize_to_fill: [200, 199]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
                         = render "modal", image: image, index: i + 1, post_id: post.id
 
             - when 5
@@ -59,12 +59,12 @@
                   .row.g-1
                     - post.images[1..2].each_with_index do |image, i|
                       .col-6.mb-1
-                        = image_tag(image.variant(resize_to_fill: [150, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
                         = render "modal", image: image, index: i + 1, post_id: post.id
                   .row.g-1
                     - post.images[3..4].each_with_index do |image, i|
                       .col-6.mb-1
-                        = image_tag(image.variant(resize_to_fill: [150, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
                         = render "modal", image: image, index: i + 1, post_id: post.id
 
             - when 6
@@ -91,7 +91,7 @@
                 .col-md-3
                   - post.images[1..2].each_with_index do |image, i|
                     .col-12.mb-1
-                      = image_tag(image.variant(resize_to_fill: [150, 225]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                      = image_tag(image.variant(resize_to_fill: [150, 228]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
                       = render "modal", image: image, index: i + 1, post_id: post.id
               .row.g-1
                 .col-md-12
@@ -110,7 +110,7 @@
                   .row.g-1
                     - post.images[1..7].each_with_index do |image, i|
                       .col-12
-                        = image_tag(image.variant(resize_to_fill: [300, 80]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
+                        = image_tag(image.variant(resize_to_fill: [300, 81]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{post.id}-#{i + 1}" })
                         = render "modal", image: image, index: i + 1, post_id: post.id
 
         .post-footer

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -63,8 +63,8 @@
                 .row.g-1
                   - @post.images[3..4].each_with_index do |image, i|
                     .col-6.mb-1
-                      = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
-                      = render "modal", image: image, index: i + 1, post_id: @post.id
+                      = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 3}" })
+                      = render "modal", image: image, index: i + 3, post_id: @post.id
 
           - when 6
             .row.g-1.mb-1
@@ -79,8 +79,8 @@
                 .row.g-1
                   - @post.images[2..5].each_with_index do |image, i|
                     .col-3.mb-1
-                      = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
-                      = render "modal", image: image, index: i + 1, post_id: @post.id
+                      = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 2}" })
+                      = render "modal", image: image, index: i + 2, post_id: @post.id
 
           - when 7
             .row.g-1.mb-1
@@ -97,8 +97,8 @@
                 .row.g-1
                   - @post.images[3..6].each_with_index do |image, i|
                     .col-3.mb-1
-                      = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
-                      = render "modal", image: image, index: i + 1, post_id: @post.id
+                      = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 3}" })
+                      = render "modal", image: image, index: i + 3, post_id: @post.id
 
           - when 8
             .row.g-1

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -11,7 +11,107 @@
             = "#{time_ago_in_words(@post.created_at)} ago"
       .post-content
         .content-images
-          = image_tag @post.images[0] if @post.images[0].present?
+          - case @post.images.size
+          - when 1
+            .row
+              .col
+                = image_tag(@post.images[0].variant(resize_to_fill: [600, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-0" })
+                = render "modal", image: post.images[0], index: 0, post_id: @post.id
+
+          - when 2
+            .row.g-1
+              - @post.images.each_with_index do |image, index|
+                .col-6
+                  = image_tag(image.variant(resize_to_fill: [150, 300]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{index}" })
+                  = render "modal", image: image, index: index, post_id: @post.id
+
+          - when 3
+            .row.g-1
+              .col-md-8
+                = image_tag(@post.images[0].variant(resize_to_fill: [400, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-0" })
+                = render "modal", image: @post.images[0], index: 0, post_id: @post.id
+              .col-md-4
+                .row.g-0
+                  - @post.images[1..2].each_with_index do |image, i|
+                    .col-12.mb-1
+                      = image_tag(image.variant(resize_to_fill: [200, 301]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: @post.id
+
+          - when 4
+            .row.g-1
+              .col-md-8
+                = image_tag(@post.images[0].variant(resize_to_fill: [400, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-0" })
+                = render "modal", image: @post.images[0], index: 0, post_id: @post.id
+              .col-md-4
+                .row
+                  - post.images[1..3].each_with_index do |image, i|
+                    .col-12.mb-1
+                      = image_tag(image.variant(resize_to_fill: [200, 199]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: @post.id
+
+          - when 5
+            .row.g-1
+              .col-md-6
+                = image_tag(@post.images[0].variant(resize_to_fill: [300, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-0" })
+                = render "modal", image: @post.images[0], index: 0, post_id: @post.id
+              .col-md-6
+                .row.g-1
+                  - @post.images[1..2].each_with_index do |image, i|
+                    .col-6.mb-1
+                      = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: @post.id
+                .row.g-1
+                  - @post.images[3..4].each_with_index do |image, i|
+                    .col-6.mb-1
+                      = image_tag(image.variant(resize_to_fill: [150, 303]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: @post.id
+
+          - when 6
+            .row.g-1.mb-1
+              .col-md-6
+                = image_tag(@post.images[0].variant(resize_to_fill: [300, 400]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-0" })
+                = render "modal", image: @post.images[0], index: 0, post_id: @post.id
+              .col-md-6
+                = image_tag(@post.images[1].variant(resize_to_fill: [300, 400]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-1" })
+                = render "modal", image: @post.images[1], index: 1, post_id: @post.id
+            .row.g-1
+              .col-md-12
+                .row.g-1
+                  - @post.images[2..5].each_with_index do |image, i|
+                    .col-3.mb-1
+                      = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: @post.id
+
+          - when 7
+            .row.g-1.mb-1
+              .col-md-9
+                = image_tag(@post.images[0].variant(resize_to_fill: [450, 450]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-0" })
+                = render "modal", image: @post.images[0], index: 0, post_id: @post.id
+              .col-md-3
+                - @post.images[1..2].each_with_index do |image, i|
+                  .col-12.mb-1
+                    = image_tag(image.variant(resize_to_fill: [150, 228]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                    = render "modal", image: image, index: i + 1, post_id: @post.id
+            .row.g-1
+              .col-md-12
+                .row.g-1
+                  - @post.images[3..6].each_with_index do |image, i|
+                    .col-3.mb-1
+                      = image_tag(image.variant(resize_to_fill: [150, 200]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: @post.id
+
+          - when 8
+            .row.g-1
+              .col-md-6
+                = image_tag(@post.images[0].variant(resize_to_fill: [300, 600]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-0" })
+                = render "modal", image: @post.images[0], index: 0, post_id: @post.id
+              .col-md-6
+                .row.g-1
+                  - @post.images[1..7].each_with_index do |image, i|
+                    .col-12
+                      = image_tag(image.variant(resize_to_fill: [300, 81]), class: "img-fluid", data: { bs_toggle: "modal", bs_target: "#imageModal-#{@post.id}-#{i + 1}" })
+                      = render "modal", image: image, index: i + 1, post_id: @post.id
+
       .post-footer
         .group
           .sign

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.16",
+    "@popperjs/core": "^2.11.8",
     "@rails/ujs": "^7.1.3-4",
     "axios": "^1.10.0",
+    "bootstrap": "^5.3.7",
     "jquery": "^3.7.1",
     "sass": "^1.89.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,11 @@
     "@parcel/watcher-win32-ia32" "2.5.1"
     "@parcel/watcher-win32-x64" "2.5.1"
 
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@rails/actioncable@>=7.0":
   version "8.0.200"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-8.0.200.tgz#1d27d9d55e45266e061190db045925e0b4d53d6b"
@@ -262,6 +267,11 @@ axios@^1.10.0:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
+
+bootstrap@^5.3.7:
+  version "5.3.7"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.7.tgz#8640065036124d961d885d80b5945745e1154d90"
+  integrity sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==
 
 braces@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
## 変更の概要
- 投稿一覧・詳細画面にBootstrapを用いたレスポンシブな画像レイアウトを導入
- サムネイルクリックでモーダル表示する仕組みを導入
- 投稿モデルにバリデーション追加
- 投稿の新着順表示を実装
- 軽微なスタイル修正やリファクタリングを実施

### 関連Issue
- close #14 

## なぜこの変更をするのか
- 投稿画像のレイアウトルールを明確にした
- モーダルによる画像プレビューを導入することで、ユーザーが投稿画像を拡大表示できるようにした
- 画像の枚数に応じてレイアウトを柔軟に変更することと、モーダルの導入のためBootstrapを導入
- バリデーションをモデルレベルで追加し、データの整合性を担保するため

## やったこと
- Bootstrapの導入
- image_processing gemの導入
- 投稿画像のレイアウト（枚数ごとの表示）を構築
- モーダル処理をパーシャルとして分離
- 投稿モデルに画像枚数・拡張子・サイズのバリデーションを追加
- 投稿のタイムラインを新着順に並び替え
- 軽微なレイアウト調整
- 投稿詳細画面に同様のレイアウトを適用

## 変更内容

### UIの変更（投稿一覧画面）
<img width="365" alt="image" src="https://github.com/user-attachments/assets/1dfd0775-603e-4bec-a412-56f2d116364f" />

### モーダルプレビュー（Bootstrap）
- 各画像はクリックでモーダル表示され、拡大可能

https://github.com/user-attachments/assets/c5288f80-9b49-46b3-a8dd-e952a3202ab7

## 影響範囲
- ユーザー：投稿画像の表示形式が変わり、UI改善
- システム：Active Storageを利用した画像管理、image_processing gemの利用が前提に

## 動作確認
- 投稿画面で1〜8枚までの画像をアップロード → 正常表示
- 投稿画像をクリック → モーダルでプレビュー表示
- 投稿詳細画面でも同様に確認
- 無効な画像形式・サイズ → バリデーションエラーを確認
- 投稿一覧が新着順に表示されることを確認