### PR TITLE
Add image preview functionality to post form using Stimulus

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,6 +9,9 @@ import '@hotwired/turbo-rails';
 import $ from 'jquery';
 import axios from 'axios';
 
+import * as ActiveStorage from '@rails/activestorage';
+ActiveStorage.start();
+
 // Stimulus Controllers
 import './controllers';
 

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from '@hotwired/stimulus';
+
+// Connects to data-controller="image-preview"
+export default class extends Controller {
+
+  connect() {}
+}

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -2,6 +2,30 @@ import { Controller } from '@hotwired/stimulus';
 
 // Connects to data-controller="image-preview"
 export default class extends Controller {
+  static targets = ['input', 'output'];
 
-  connect() {}
+  connect() {
+  }
+
+  preview() {
+    // ファイルを取得
+    const files = this.inputTarget.files;
+    this.outputTarget.innerHTML = ''; // プレビュー領域を一旦クリア
+
+    // ファイルごとにプレビュー画像を生成
+    Array.from(files).forEach((file) => {
+      if (!file.type.match('image.*')) return;
+
+      const reader = new FileReader();
+
+      reader.onload = (e) => {
+        const img = document.createElement('img');
+        img.src = e.target.result;
+        img.classList.add('m-1', 'rounded', 'shadow-sm');
+        img.style.maxWidth = '190px';
+        this.outputTarget.appendChild(img);
+      };
+      reader.readAsDataURL(file);
+    });
+  }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,8 +1,9 @@
-
 import { Application } from '@hotwired/stimulus';
 import HelloController from './hello_controller';
+import ImagePreviewController from './image_preview_controller';
 
 const application = Application.start();
 application.register('hello', HelloController);
+application.register('image-preview', ImagePreviewController);
 
 export { application };

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -12,11 +12,13 @@
       .user-info
         = current_user.account
 
-    = form_with(model: @post, local: true) do |f|
+    = form_with(model: @post, local: true, html: { multipart: true }) do |f|
       .post-form
         .caption
           = f.text_field :caption, placeholder: "What's on your mind ?", class: 'text'
-        .images
-          = f.label :images, '+ Album'
-          = f.file_field :images, multiple: true, class: 'hidden'
+        .images{ data: { controller: "image-preview" } }
+          = f.label :images, '+ Album', for: 'image_upload'
+          = f.file_field :images, multiple: true, accept: 'image/*', id: 'image_upload', class: 'hidden', data: { action: "change->image-preview#preview", image_preview_target: "input" }
+          #preview{ data: { image_preview_target: "output" } }
+
         = f.submit 'Post', class: 'nav-right btn-secondary'


### PR DESCRIPTION
## 変更の概要

- 投稿作成フォームに画像プレビュー機能を追加しました。
- Stimulus コントローラを利用して、ファイル選択時に画像のプレビューを表示します。

### 関連 Issue:
- close #13 

## なぜこの変更をするのか

- 画像投稿時に、どの画像を選択したのか確認したいため。
- 投稿前のユーザー体験向上のために、選択した画像を視覚的に確認できるようにする必要がありました。

## やったこと

* [x] Stimulus コントローラの生成
* [x] FileReader API を使ったプレビュー機能の実装
* [x] ActiveStorage の初期化
* [x] form_with に対応する HAML 修正（data 属性追加など）
* [x] デザイン調整

## 変更内容

- UIの変更
画像ファイルを選択すると、投稿フォーム内でそのプレビューが即時表示されます。

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3f77e4b8-fd9d-447e-9cb7-172eade53713" />

## 影響範囲

- ユーザー
投稿時に画像の選択内容を確認できるようになります。
- 開発者
特になし（Stimulus を使用しているため、他の部分に影響しません）
- システム
ActiveStorage を使っているため、他のアップロード機能に依存関係がある場合は注意が必要です。

## 動作確認

- bin/dev でアプリを起動し、投稿フォームに画像を複数選択 → プレビュー表示されるか確認済み。
- .hidden クラスにより、ファイル選択 UI は隠れており、ラベルクリックで選択可能。

## 備考

- 画像の並び替えやドラッグ＆ドロップ機能を導入する余地があります。