### PR TITLE
Add comment feature with UI, API, and validations

### DIFF
--- a/app/assets/images/arrow-up-circle.svg
+++ b/app/assets/images/arrow-up-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-circle" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8m15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-7.5 3.5a.5.5 0 0 1-1 0V5.707L5.354 7.854a.5.5 0 1 1-.708-.708l3-3a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 5.707z"/>
+</svg>

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -21,5 +21,6 @@ $text-base-color: #333;
 $text-light-color: #fff;
 
 $avatar-s: 30px;
+$avatar-sm: 32px;
 $avatar-m: 40px;
 $avatar-l: 75px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @use 'common';
 @use 'post';
 @use 'profile';
+@use 'comment';
 
 html {
   word-spacing: 1px;
@@ -25,6 +26,7 @@ html {
 
 body {
   height: 100%;
+  font-family: 'poppins', sans-serif;
   background-color: variables.$base-bg-color;
   color: variables.$text-base-color;
 }

--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -36,6 +36,10 @@ $image_size: variables.$avatar-sm;
   display: flex;
   align-items: center;
   width: 400px;
+  background-color: variables.$base-bg-color;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.125);
+  position: fixed;
+  bottom: 30px;
 
   img {
     width: 100%;

--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -31,3 +31,28 @@ $image_size: variables.$avatar-sm;
     }
   }
 }
+
+.comment-footer {
+  display: flex;
+  align-items: center;
+  width: 400px;
+
+  img {
+    width: 100%;
+  }
+
+  .comment-img {
+    margin: 20px;
+    width: 20px;
+  }
+
+  .comment-form {
+    flex-grow: 1;
+    margin-top: 10px;
+  }
+
+  .comment-submit {
+    margin: 5px 10px;
+    width: 20px;
+  }
+}

--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -1,0 +1,33 @@
+@use 'variables';
+
+$image_size: variables.$avatar-sm;
+
+.comments-container {
+  .post-comment {
+    display: flex;
+    margin: 40px 0;
+
+    .comment-img {
+      margin: 5px 20px;
+
+      img {
+        width: $image_size;
+        height: $image_size;
+        border-radius: 50%;
+        object-fit: cover;
+      }
+    }
+
+    .comment-text {
+      &-user {
+        color: variables.$gray-deep;
+        font-size: variables.$font-lg;
+        margin-bottom: 5px;
+      }
+
+      &-body {
+        color: variables.$gray-dark;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -98,7 +98,6 @@
 .btn-secondary {
   background-color: variables.$base-bg-color;
   border: none;
-  // text-align: center;
   color: variables.$gray-bright;
   font-weight: 400;
   font-family: variables.$base-font;

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -18,19 +18,22 @@ input,
 select {
   &.text {
     @include form-control;
-  }
 
-  ::placeholder {
-    color: variables.$gray-dark;
+    &::placeholder {
+      color: variables.$gray-dark;
+    }
   }
 }
 
 textarea {
-  @include form-control(203px);
-  resize: vertical;
+  &.text {
+    @include form-control(35px);
+    resize: vertical;
+    font-size: variables.$font-base;
 
-  ::placeholder {
-    color: variables.$gray-dark;
+    &::placeholder {
+      color: variables.$gray-brilliant;
+    }
   }
 }
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,20 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @post = Post.find(params[:post_id])
+    @comments = @post.comments.includes(:user)
+
+    respond_to do |format|
+      format.html
+      format.json {
+        render json: @comments.to_json(include: {
+          user: {
+            only: [:account],
+            methods: [:avatar_url]
+          }
+        })
+      }
+    end
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,4 +17,23 @@ class CommentsController < ApplicationController
       }
     end
   end
+
+  def create
+    post = Post.find(params[:post_id])
+    @comment = post.comments.build(comment_params)
+    @comment.user = current_user
+
+    if @comment.save
+      render json: @comment.as_json(include: { user: { only: [:account], methods: [:avatar_url] } })
+    else
+      render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body)
+  end
+
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -122,6 +122,41 @@ document.addEventListener('turbo:load', () => {
       $btn.addClass('offscreen');
     }
   });
+
+  ///////////////////
+  // コメント投稿機能 //
+  ///////////////////
+  $('.comment-btn').on('click', () => {
+    const body = $('#comment_body').val();
+
+    if (!body) {
+      flash('コメントを入力してください');
+    } else {
+      axios
+        .post(`/posts/${postId}/comments`, {
+          comment: { body: body },
+        })
+        .then((res) => {
+          const comment = res.data;
+          $('.comments-container').append(
+            `<div class="post-comment"><div class="comment-img"><img src="${comment.user.avatar_url}" alt="avatar"></div><div class="comment-text"><div class="comment-text-user">${comment.user.account}</div><div class="comment-text-body">${comment.body}</div></div></div>`
+          );
+          $('#comment_body').val('');
+        })
+        .catch((error) => {
+          if (error.response && error.response.status === 422) {
+            const errors = error.response.data.errors;
+            if (errors && Array.isArray(errors)) {
+              flash(`エラー： ${errors.join(', ')}`);
+            } else {
+              flash('コメントの投稿に失敗しました');
+            }
+          } else {
+            flash('予期しないエラーが発生しました');
+          }
+        });
+    }
+  });
 });
 
 // flash 表示

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -94,6 +94,20 @@ document.addEventListener('turbo:load', () => {
       });
     });
   });
+
+  ////////////////
+  // コメント表示 //
+  ////////////////
+  const dataset = $(`#post-show`).data();
+  const postId = dataset.postId;
+  axios.get(`/posts/${postId}/comments.json`).then((res) => {
+    const comments = res.data;
+    comments.forEach((comment) => {
+      $('.comments-container').append(
+        `<div class="post-comment"><div class="comment-img"><img src="${comment.user.avatar_url}" alt="avatar"></div><div class="comment-text"><div class="comment-text-user">${comment.user.account}</div><div class="comment-text-body">${comment.body}</div></div></div>`
+      );
+    });
+  });
 });
 
 // flash 表示

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -108,6 +108,20 @@ document.addEventListener('turbo:load', () => {
       );
     });
   });
+
+  //////////////////////////////////////////
+  // コメントを入力したら投稿ボタン ↑ を表示する //
+  //////////////////////////////////////////
+  $('.comment-body').on('input', function () {
+    const value = $(this).val().trim();
+    const $btn = $('.comment-btn');
+
+    if (value.length > 0) {
+      $btn.removeClass('offscreen');
+    } else {
+      $btn.addClass('offscreen');
+    }
+  });
 });
 
 // flash 表示

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,4 +18,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :body, presence: true, length: { maximum: 400 }
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :integer          not null, primary key
+#  body       :text
+#  user_id    :integer          not null
+#  post_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_comments_on_post_id  (post_id)
+#  index_comments_on_user_id  (user_id)
+#
+
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,6 +16,7 @@
 class Post < ApplicationRecord
   has_many_attached :images
 
+  has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_one_attached :avatar
 
   has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 
   validates :account, presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,4 +41,8 @@ class User < ApplicationRecord
     likes.exists?(post_id: post.id)
   end
 
+  def avatar_url
+    avatar.attached? ? Rails.application.routes.url_helpers.rails_blob_url(avatar, host: 'http://localhost:3000') : nil
+  end
+
 end

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -1,0 +1,5 @@
+.container
+  .card
+    .heading
+      Comment
+    .comments-container#post-show{data: {post_id: @post.id}}

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -3,3 +3,10 @@
     .heading
       Comment
     .comments-container#post-show{data: {post_id: @post.id}}
+    .comment-footer
+      .comment-img
+        = image_tag 'comment.svg'
+      .comment-form
+        = text_area_tag :comment_body, '', placeholder: 'Leave a comment...', class: 'text comment-body'
+      .comment-submit
+        = image_tag 'arrow-up-circle.svg', class: 'comment-btn offscreen'

--- a/app/views/commons/_post.html.haml
+++ b/app/views/commons/_post.html.haml
@@ -119,7 +119,8 @@
           .offscreen.inactive-heart
             = image_tag 'heart-blank.svg'
       .sign
-        = image_tag 'comment.svg'
+        = link_to post_comments_path(post) do
+          = image_tag 'comment.svg'
       .sign
         = link_to "https://twitter.com/share?url=#{CGI.escape(post.url)}&text=#{CGI.escape("【テスト】\n\n#{post.caption}")}", target: "_blank", rel: "noopener" do
           = image_tag 'link.svg'

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -26,6 +26,8 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+      comment:
+        body: コメント内容
     models:
       user: ユーザ
   devise:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   resource :user, only: [:show, :update]
 
   resources :posts, only: [:show, :new, :create] do
+    resources :comments, only: [:index, :create]
     resource :like, only: [:show, :create, :destroy]
   end
 

--- a/db/migrate/20250723125732_create_comments.rb
+++ b/db/migrate/20250723125732_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comments do |t|
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_23_052204) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_23_125732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_23_052204) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -75,5 +85,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_23_052204) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "posts", "users"
 end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :integer          not null, primary key
+#  body       :text
+#  user_id    :integer          not null
+#  post_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_comments_on_post_id  (post_id)
+#  index_comments_on_user_id  (user_id)
+#
+
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  body: MyText
+  user: one
+  post: one
+
+two:
+  body: MyText
+  user: two
+  post: two

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :integer          not null, primary key
+#  body       :text
+#  user_id    :integer          not null
+#  post_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_comments_on_post_id  (post_id)
+#  index_comments_on_user_id  (user_id)
+#
+
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要
- コメント機能の追加
- コメント投稿・表示・バリデーション・スタイル・エラーハンドリングを一通り実装

### 関連するIssue:
- close #24 

## やったこと
- Commentモデルとマイグレーション追加（bodyとuser_id, post_idの関連付け）
- コメントのルーティング追加（resources :posts do resources :comments）
- コメントのインデックスAPI追加（JSON形式でアカウント名とアバターURL付きで返す）
- コメントの投稿API追加（成功時にコメント＋ユーザー情報をJSONで返し、失敗時にバリデーションエラーを返す）
- JavaScript（Axios）でコメントの取得・描写・投稿処理・バリデーションエラー表示を実装
- コメント入力時にボタンを表示する機能を実装
- コメントフォームを画面下に固定し、デザインに合わせてスタイルを調整
- i18n によるエラーメッセージ（「Body」→「コメント内容」など）表示対応

## 変更内容

### フロントエンド
- コメント入力フォームを画面下に固定配置（.comment-form）
- 入力内容があると送信ボタンを表示するJS実装
- コメントの描写処理（ユーザーのアバター、アカウント、コメント内容）

### バックエンド

- コメント取得 API（GET /posts/:post_id/comments.json）

  ```json
  [
    {
      "id": 1,
      "body": "これはコメントです",
      "user": {
        "account": "aym0546",
        "avatar_url": "/.../avatar.png"
      }
    }
  ]
  ```

- コメント投稿 API（POST /posts/:post_id/comments）

   - 成功時:
    ```json
    {
      "id": 2,
      "body": "新しいコメント",
      "user": {
        "account": "aym0546",
        "avatar_url": "/.../avatar.png"
      }
    }
    ```

   - 失敗時（例：文字数オーバー）:
    ```json
    {
      "errors": ["コメント内容 は 400文字以内 で入力してください"]
    }
    ```

## 影響範囲
- 投稿詳細ページにコメントUIが追加され、ユーザーがコメントできるようになります
- コメントに関するバリデーションやスタイル調整により、ユーザー体験が向上します
- JavaScriptやStimulusとの統合により、今後の開発でも Stimulus をベースにした拡張が可能になります

## 動作確認

https://github.com/user-attachments/assets/0ff41082-3b46-4d68-aea5-aa9d6071e9d5

- コメント一覧が表示されることを確認
- コメントを入力して送信 → 即座に画面に反映されることを確認
- 空入力や文字数オーバーなどでエラーメッセージが表示されることを確認

## 課題
- JavaScriptがStimulusとベタ書きの Axios で混在している状態
- いずれ Stimulus controller に統一していきたい

## 備考
- スタイルは figma などのデザインに可能な範囲で準拠
- バリデーション項目は `presence: true, length: { maximum: 400 }` で設定