### PR TITLE
Add timeline feed with followed users and hot posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,13 @@
 class PostsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:index, :new, :create]
+
   def index
-    @posts = Post.all.order(created_at: :desc)
+    @posts = Post
+              .left_joins(:likes)
+              .where('posts.created_at >= ?', 24.hours.ago)
+              .group('posts.id')
+              .order('COUNT(likes.id) DESC')
+              .limit(5)
   end
 
   def show


### PR DESCRIPTION
## 変更の概要

* フォローしているユーザーの投稿と、直近24時間以内の「いいね」数上位5件の投稿を表示するタイムラインを実装

## やったこと

* [x] フォローしているユーザーの投稿を取得
* [x] 過去24時間以内の人気投稿を取得（`likes`の数順）
* [x] それらをマージし、作成日時の降順で表示（最大5件）

## 変更内容

* UI：投稿一覧の表示ロジックのみ変更
* API変更なし
* controller（`PostsController#index`）内のロジックを変更

## 影響範囲

* ユーザー：タイムラインの内容が変化（より動的かつ関連性の高い投稿が表示される）

## 動作確認

* ログイン中のユーザーでタイムラインを確認
* フォロー中のユーザーが投稿していること
* 「いいね」数の多い投稿が表示されていること
* 表示件数が5件以内であること

## 課題

* N+1の懸念は `.includes(:user, :likes)` により最小限にしているが、インデックスやスケーラビリティは要監視